### PR TITLE
Add initial port of Java based Task and TaskService along with their tests; setup flask blueprint skeleton with dummy route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Idea
+.idea/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,9 @@ def create_app(testing=False):
         )
 
     from app.main import bp as main_bp
+    from app.task import bp as task_bp
 
     app.register_blueprint(main_bp)
+    app.register_blueprint(task_bp)
 
     return app

--- a/app/task/__init__.py
+++ b/app/task/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("task", __name__)
+
+from app.task import routes

--- a/app/task/models.py
+++ b/app/task/models.py
@@ -1,0 +1,55 @@
+class Task:
+    def __init__(self, task_id, name, description):
+        self._task_id = None
+        self._name = None
+        self._description = None
+
+        # use @property setters to handle validation
+        self.task_id = task_id
+        self.name = name
+        self.description = description
+
+    @property
+    def task_id(self):
+        return self._task_id
+
+    @task_id.setter
+    def task_id(self, value):
+        if self._task_id is not None:
+            raise AttributeError("task_id is immutable and cannot be changed once set.")
+        if value is None or len(value) > 10:
+            raise ValueError(
+                "Invalid task_id: must be non-null and <= 10 characters long."
+            )
+        self._task_id = value
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        if value is None or len(value) > 20:
+            raise ValueError(
+                "Invalid task name: must be non-null and <= 20 characters long."
+            )
+        self._name = value
+
+    @property
+    def description(self):
+        return self._description
+
+    @description.setter
+    def description(self, value):
+        if value is None or len(value) > 50:
+            raise ValueError(
+                "Invalid description: must be non-null and <= 50 characters long."
+            )
+        self._description = value
+
+    def to_dict(self):
+        return {
+            "id": self.task_id,
+            "name": self.name,
+            "description": self.description,
+        }

--- a/app/task/routes.py
+++ b/app/task/routes.py
@@ -1,0 +1,6 @@
+from app.task import bp
+
+
+@bp.route("/tasks")
+def task():
+    return "Task Page"

--- a/app/task/service.py
+++ b/app/task/service.py
@@ -1,0 +1,31 @@
+from .models import Task
+
+class TaskService:
+    def __init__(self):
+        self.tasks = []
+        self.next_task_id = 1
+
+    def create_task(self, name, description=None):
+        task_id = str(self.next_task_id)
+
+        if any(task.task_id == task_id for task in self.tasks):
+            raise ValueError(f"Task with id '{task_id}' already exists")
+
+        task = Task(task_id, name, description)
+        self.tasks.append(task)
+        self.next_task_id += 1
+        return task
+
+    def get_task(self, task_id):
+        for task in self.tasks:
+            if task.task_id == task_id:
+                return task
+
+        raise ValueError(f"Task with id '{task_id}' not found")
+
+    def list_tasks(self):
+        return self.tasks
+
+    def delete_task(self, task_id):
+        task = self.get_task(task_id)
+        self.tasks.remove(task)

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -18,3 +18,8 @@ def test_homepage(client):
     assert response.status_code == 200
     assert b"Test Page" in response.data
 
+
+def test_taskpage(client):
+    response = client.get("/tasks")
+    assert response.status_code == 200
+    assert b"Task Page" in response.data

--- a/test/task_service_test.py
+++ b/test/task_service_test.py
@@ -1,0 +1,102 @@
+import pytest
+from app.task.models import Task
+from app.task.service import TaskService
+
+@pytest.fixture
+def task_service():
+    return TaskService()
+
+
+@pytest.fixture
+def sample_tasks():
+    return [
+        Task("task1", "Task 1", "Description for Task 1"),
+        Task("task2", "Task 2", "Description for Task 2"),
+        Task("task3", "Task 3", "Description for Task 3"),
+    ]
+
+
+def test_add_single_task(task_service, sample_tasks):
+    task_service.tasks.append(sample_tasks[0])
+    tasks = task_service.list_tasks()
+    assert len(tasks) == 1
+    assert tasks[0] == sample_tasks[0]
+
+
+def test_add_multiple_tasks(task_service, sample_tasks):
+    for task in sample_tasks:
+        task_service.tasks.append(task)
+    tasks = task_service.list_tasks()
+    assert len(tasks) == 3
+    assert tasks[0] == sample_tasks[0]
+    assert tasks[1] == sample_tasks[1]
+    assert tasks[2] == sample_tasks[2]
+
+
+def test_delete_single_task(task_service, sample_tasks):
+    task_service.tasks.append(sample_tasks[0])
+    tasks = task_service.list_tasks()
+    assert len(tasks) == 1
+
+    task_service.delete_task("task1")
+    with pytest.raises(ValueError):
+        task_service.get_task("task1")
+    assert len(task_service.list_tasks()) == 0
+
+
+def test_get_task_by_id(task_service, sample_tasks):
+    task_service.tasks.append(sample_tasks[0])
+    found_task = task_service.get_task("task1")
+    assert found_task is not None
+    assert found_task == sample_tasks[0]
+
+
+def test_update_task_name(task_service):
+    task = Task("task1", "Task 1", "Description for Task 1")
+    task_service.tasks.append(task)
+    # simulate update call
+    task.name = "Updated Task Name"
+
+    updated_task = task_service.get_task("task1")
+    assert updated_task.name == "Updated Task Name"
+    assert updated_task.name != "Task 1"
+    assert updated_task.description == "Description for Task 1"
+
+
+def test_update_task_description(task_service):
+    task = Task("task1", "Task 1", "Description for Task 1")
+    task_service.tasks.append(task)
+    task.description = "Updated Task Description"
+
+    updated_task = task_service.get_task("task1")
+    assert updated_task.name == "Task 1"
+    assert updated_task.description == "Updated Task Description"
+    assert updated_task.description != "Description for Task 1"
+
+
+def test_add_task_already_exists(task_service):
+    task_service.create_task("First Task", "First description")
+
+    # reset taskID to old value
+    task_service.next_task_id = 1
+
+    # creating another task should raise ValueError
+    with pytest.raises(ValueError, match="already exists"):
+        task_service.create_task("Duplicate Task", "Should fail")
+
+
+def test_delete_task_not_found(task_service):
+    with pytest.raises(ValueError):
+        if not task_service.delete_task("task1"):
+            raise ValueError("Task not found")
+
+
+def test_update_task_name_not_found(task_service):
+    with pytest.raises(ValueError):
+        task_service.get_task("nonexistentTask")
+
+
+def test_update_task_description_not_found(task_service):
+    with pytest.raises(ValueError, match="Task with id 'nonexistentTask' not found"):
+        task_service.get_task("nonexistentTask")
+

--- a/test/task_test.py
+++ b/test/task_test.py
@@ -1,0 +1,81 @@
+import pytest
+from app.task.models import Task
+
+valid_task_id = "1"
+valid_name = "taskname"
+valid_description = "null"
+
+invalid_task_id_too_long = "12345678901"
+invalid_task_id_null = None
+invalid_name_too_long = "TooLongOfANameForTask"
+invalid_description_too_long = "TooLongDescriptionForTaskThatIsInvalidBecauseItIsMoreThan50Characters"
+
+
+@pytest.fixture
+def valid_task():
+    return Task(valid_task_id, valid_name, valid_description)
+
+
+def test_valid_task_constructor(valid_task):
+    assert valid_task.task_id == valid_task_id
+    assert valid_task.name == valid_name
+    assert valid_task.description == valid_description
+
+
+def test_invalid_task_constructor_task_id_too_long():
+    with pytest.raises(ValueError):
+        Task(invalid_task_id_too_long, valid_name, valid_description)
+
+
+def test_invalid_task_constructor_task_id_null():
+    with pytest.raises(ValueError):
+        Task(invalid_task_id_null, valid_name, valid_description)
+
+
+def test_valid_set_name(valid_task):
+    new_name = "NewName"
+    valid_task.name = new_name
+    assert valid_task.name == new_name
+
+
+def test_valid_set_description(valid_task):
+    new_description = "New description for the task."
+    valid_task.description = new_description
+    assert valid_task.description == new_description
+
+
+def test_invalid_set_name_null(valid_task):
+    with pytest.raises(ValueError):
+        valid_task.name = None
+
+
+def test_invalid_set_name_too_long(valid_task):
+    with pytest.raises(ValueError):
+        valid_task.name = invalid_name_too_long
+
+
+def test_invalid_set_description_null(valid_task):
+    with pytest.raises(ValueError):
+        valid_task.description = None
+
+
+def test_invalid_set_description_too_long(valid_task):
+    with pytest.raises(ValueError):
+        valid_task.description = invalid_description_too_long
+
+
+def test_get_task_id(valid_task):
+    assert valid_task.task_id == valid_task_id
+
+
+def test_get_name(valid_task):
+    assert valid_task.name == valid_name
+
+
+def test_get_description(valid_task):
+    assert valid_task.description == valid_description
+
+
+def test_task_id_immutable(valid_task):
+    with pytest.raises(AttributeError):
+        valid_task.task_id = "new_id"


### PR DESCRIPTION
Porting the Java code for Tasks and TaskService as close as possible to their native setup. Python doesn't have getters/setters so I'm using properties to implement them but may remove them later in favor of more pythonic code.

TaskService is also a class still but can likely be switched to a module later to match the standard for flask apps. Tests are ported as closely as possible to JUnit using pytest fixtures and the same tests and validations that previously existed.

By porting the code and tests in this manner it will make any refactoring easier later.